### PR TITLE
Fixes a critial breaking error with the minified build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,9 @@
 dependencies:
   override:
     - npm install
-    - npm install -g karma webpack
 
 test:
   override:
-    - webpack
-    - webpack --config webpack.config.min.js
-    - ./node_modules/karma/bin/karma start --single-run
+    - ./node_modules/.bin/webpack
+    - ./node_modules/.bin/webpack --config webpack.config.min.js
+    - ./node_modules/.bin/karma start --single-run

--- a/circle.yml
+++ b/circle.yml
@@ -5,4 +5,6 @@ dependencies:
 
 test:
   override:
+    - webpack
+    - webpack --config webpack.config.min.js
     - ./node_modules/karma/bin/karma start --single-run

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   override:
     - npm install
+    - npm rebuild node-sass
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   override:
     - npm install
-    - npm install -g karma
+    - npm install -g karma webpack
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  node:
+    version: 0.12.7
+
 dependencies:
   override:
     - npm install

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,8 +18,7 @@ module.exports = function(config) {
       { pattern: 'test/*.spec.js',          included: true,  served: true, watched: true },
       { pattern: 'test/fixtures/**/*.html', included: false, served: true, watched: true },
       { pattern: 'misc/**/*.*',             included: false, served: true, watched: false },
-      { pattern: 'dist/booking.js',         included: false, served: true, watched: true },
-      { pattern: 'dist/booking.js.map',     included: false, served: true, watched: false }
+      { pattern: 'dist/**/*',               included: false, served: true, watched: true }
     ],
 
     // list of files to exclude

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "https://github.com/timekit/booking.git"
   },
+  "scripts": {
+    "test": "karma start --single-run",
+    "compile": "webpack",
+    "compile:production": "webpack --config webpack.config.min.js"
+  },
   "author": "Timekit Inc.",
   "license": "MIT",
   "devDependencies": {

--- a/test/fixtures/minified.html
+++ b/test/fixtures/minified.html
@@ -1,0 +1,16 @@
+<html>
+ <head>
+  <meta charset="UTF-8">
+  <title>Booking.js main fixture</title>
+  <style type="text/css">
+    body { background-color: #E6E6E6; max-width: 700px; margin: 0 auto; }
+  </style>
+ </head>
+ <body>
+
+  <script type="text/javascript" src="/base/dist/booking.min.js"></script>
+
+  <div id="bookingjs"></div>
+
+</body>
+</html>

--- a/test/initialization.spec.js
+++ b/test/initialization.spec.js
@@ -6,7 +6,7 @@ var baseConfig = require('./utils/defaultConfig');
 var mockAjax = require('./utils/mockAjax');
 
 /**
- * Intilialize the library
+ * Intilialize the library with plain build
  */
 describe('Initialization regular', function() {
 
@@ -42,6 +42,42 @@ describe('Initialization regular', function() {
   it('should be able init and display the widget with singleton pattern', function() {
 
     TimekitBooking().init(baseConfig);
+
+    expect($('.bookingjs-calendar')).toBeInDOM();
+
+  });
+
+});
+
+/**
+ * Intilialize the library with minified build
+ */
+describe('Initialization minified', function() {
+
+  beforeEach(function(){
+    loadFixtures('minified.html');
+    mockAjax();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  it('should be able to load the fixture page', function() {
+
+    expect(window).toBeDefined();
+    expect($).toBeDefined();
+    expect($('#bookingjs')).toBeInDOM();
+
+  });
+
+  it('should be able init and display the widget with instance pattern', function() {
+
+    var widget = new TimekitBooking();
+    widget.init(baseConfig);
+
+    expect(widget).toBeDefined();
+    expect(widget.getConfig()).toBeDefined();
 
     expect($('.bookingjs-calendar')).toBeInDOM();
 

--- a/webpack.config.min.js
+++ b/webpack.config.min.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     module: {
         loaders: [
-            { test: /\.html$/, loader: 'mustache' },
+            { test: /\.html$/, loader: 'mustache?noShortcut' },
             { test: /\.css$/, loaders: ['style?singleton', 'css?minimize', 'autoprefixer'] },
             { test: /\.scss$/, loaders: ['style?singleton', 'css?minimize', 'autoprefixer', 'sass'] },
             { test: /\.svg$/, loader: 'svg-inline' }


### PR DESCRIPTION
In last release, the following line was changed in the regular build, but not in the minified build:
`{ test: /\.html$/, loader: 'mustache?noShortcut' },`

Made tests to make sure it doesn't happen again (tests whether library can init)