### PR TITLE
Display error and reset booking form if API rejects submit

### DIFF
--- a/src/assets/error-icon.svg
+++ b/src/assets/error-icon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg class="bookingjs-closeicon" width="90px" height="90px" viewBox="0 0 90 90" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.3 (12072) - http://www.bohemiancoding.com/sketch -->
+    <title>error-icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="error-icon" sketch:type="MSLayerGroup" fill="#FFFFFF">
+            <path d="M58,45 L87.2,15.8 C90.9,12.1 90.9,6.3 87.3,2.7 C83.7,-0.9 77.8,-0.8 74.2,2.8 L45,32 L15.8,2.8 C12.1,-0.9 6.3,-0.9 2.7,2.7 C-0.9,6.3 -0.8,12.2 2.8,15.8 L32,45 L2.8,74.2 C-0.9,77.9 -0.9,83.7 2.7,87.3 C6.3,90.9 12.2,90.8 15.8,87.2 L45,58 L74.2,87.2 C77.9,90.9 83.7,90.9 87.3,87.3 C90.9,83.7 90.8,77.8 87.2,74.2 L58,45 L58,45 Z" id="Shape" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/src/main.js
+++ b/src/main.js
@@ -220,12 +220,12 @@ function TimekitBooking() {
   var decideCalendarSize = function() {
 
     var view = 'agendaWeek';
-    var height = 470;
+    var height = 420;
     var rootWidth = rootTarget.width();
 
     if (rootWidth < 480) {
       view = 'basicDay';
-      height = 346;
+      height = 335;
       rootTarget.addClass('is-small');
     } else {
       rootTarget.removeClass('is-small');
@@ -299,6 +299,7 @@ function TimekitBooking() {
       closeIcon:            require('!svg-inline!./assets/close-icon.svg'),
       checkmarkIcon:        require('!svg-inline!./assets/checkmark-icon.svg'),
       loadingIcon:          require('!svg-inline!./assets/loading-spinner.svg'),
+      errorIcon:            require('!svg-inline!./assets/error-icon.svg'),
       submitText:           'Book it',
       successMessageTitle:  'Thanks!',
       successMessagePart1:  'An invitation has been sent to:',
@@ -360,7 +361,7 @@ function TimekitBooking() {
     var formElement = $(form);
 
     // Abort if form is submitting, have submitted or does not validate
-    if(formElement.hasClass('loading') || formElement.hasClass('success') || !e.target.checkValidity()) {
+    if(formElement.hasClass('loading') || formElement.hasClass('success') || formElement.hasClass('error') || !e.target.checkValidity()) {
       var submitButton = formElement.find('.bookingjs-form-button');
       submitButton.addClass('button-shake');
       setTimeout(function() {
@@ -387,7 +388,20 @@ function TimekitBooking() {
       formElement.removeClass('loading').addClass('success');
 
     }).catch(function(response){
+
       utils.doCallback('createEventFailed', config, response);
+
+      var submitButton = formElement.find('.bookingjs-form-button');
+      submitButton.addClass('button-shake');
+      setTimeout(function() {
+        submitButton.removeClass('button-shake');
+      }, 500);
+
+      formElement.removeClass('loading').addClass('error');
+      setTimeout(function() {
+        formElement.removeClass('error');
+      }, 2000);
+
       throw new Error('TimekitBooking - An error with Timekit createEvent occured, context: ' + response);
     });
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -16,6 +16,7 @@ $textColor:         #333;
 $textLightColor:    #AEAEAE;
 $primaryColor:      #689AD8;
 $primaryDarkColor:  darken($primaryColor, 10%);
+$errorColor:        #D83B46;
 $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
 
 // Classes
@@ -157,13 +158,12 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
       text-align: center;
       font-size: 34px;
       font-weight: 400;
-      margin-top: 90px;
-      margin-bottom: 20px;
+      margin-top: 70px;
+      margin-bottom: 10px;
 
       .is-small & {
-        font-size: 24px;
+        font-size: 27px;
         margin-top: 60px;
-        margin-bottom: 15px;
       }
     }
 
@@ -171,11 +171,12 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
       text-align: center;
       font-size: 17px;
       font-weight: 400;
-      margin-bottom: 70px;
+      margin-bottom: 50px;
+      margin-top: 10px;
 
       .is-small & {
         font-size: 15px;
-        margin-bottom: 30px;
+        margin-bottom: 35px;
       }
     }
   }
@@ -278,27 +279,31 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
       max-width: 200px;
 
       .success-text,
+      .error-text,
       .loading-text {
         transition: opacity 0.3s ease;
         position: absolute;
         top: 13px;
         left: 50%;
         transform: translateX(-50%);
+        opacity: 0;
       }
 
       .inactive-text {
+        white-space: nowrap;
         opacity: 1;
-      }
-
-      .loading-text,
-      .success-text {
-        opacity: 0;
       }
 
       .loading-text svg {
         height: 19px;
         width: 19px;
         animation: spin 0.6s infinite linear;
+      }
+
+      .error-text svg {
+        height: 15px;
+        width: 15px;
+        margin-top: 2px;
       }
 
       .success-text svg {
@@ -321,17 +326,28 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
     &.loading &-button:hover {
       max-width: 80px;
       background-color: #B1B1B1;
+      cursor: not-allowed;
 
       .inactive-text { opacity: 0; }
       .loading-text { opacity: 1; }
+    }
+
+    &.error &-button,
+    &.error &-button:hover {
+      max-width: 80px;
+      background-color: $errorColor;
+      cursor: not-allowed;
+
+      .inactive-text { opacity: 0; }
+      .error-text { opacity: 1; }
     }
 
     &.success &-button,
     &.success &-button:hover {
       max-width: 80px;
       background-color: #5BAF56;
+      cursor: not-allowed;
 
-      .loading-text,
       .inactive-text { opacity: 0; }
       .success-text { opacity: 1; }
 

--- a/src/templates/booking-page.html
+++ b/src/templates/booking-page.html
@@ -19,6 +19,7 @@
     <button class="bookingjs-form-button" type="submit">
       <span class="inactive-text">{{ submitText }}</span>
       <span class="loading-text">{{& loadingIcon }}</span>
+      <span class="error-text">{{& errorIcon }}</span>
       <span class="success-text">{{& checkmarkIcon }}</span>
     </button>
   </form>


### PR DESCRIPTION
Fixes a problem where the a malformed email isn't caught by the frontend form validation and the API returns 422, leaving the form in limbo between loading and error state.

This change will display a brief error indication and give the user the opportunity to re-submit afterwards.

Note: there's still a usability problem as the specific error isn't displayed, because the API response is hard to programmatically decipher and output