### PR TITLE
Sync provider by default after event created

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -59,7 +59,8 @@ var primary = {
   },
   timekitCreateEvent: {
     invite: true,
-    my_rsvp: 'needsAction'
+    my_rsvp: 'needsAction',
+    sync_provider: true
   },
   fullCalendar: {
     header: {


### PR DESCRIPTION
Fixes an issue where newly created bookings are not considered for availability immediately after