### PR TITLE
Protocol-agnostic URLs to cdn in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The simplest and most universally compatible usage is with autoload. This will d
 
 ```html
 <div id="bookingjs">
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <script type="text/javascript" src="http://cdn.timekit.io/booking-js/v1/booking.min.js" defer></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+  <script type="text/javascript" src="//cdn.timekit.io/booking-js/v1/booking.min.js" defer></script>
   <script type="text/javascript">
     window.timekitBookingConfig = {
       email:    'marty.mcfly@timekit.io',
@@ -63,8 +63,8 @@ If you intent to run multiple instances or want more control, just create a new 
 
 ```html
 <div id="bookingjs">
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <script type="text/javascript" src="http://cdn.timekit.io/booking-js/v1/booking.min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+  <script type="text/javascript" src="//cdn.timekit.io/booking-js/v1/booking.min.js"></script>
   <script type="text/javascript">
     var widget = new TimekitBooking();
     widget.init({
@@ -75,13 +75,6 @@ If you intent to run multiple instances or want more control, just create a new 
   </script>
 </div>
 ```
-
-**Serve over HTTPS**
-
-Use the following URI to the library if you want it served with SSL:  
-`https://dbhpllgef527b.cloudfront.net/booking-js/v1/booking.min.js`
-
-(see [this issue](https://github.com/timekit-io/booking-js/issues/19) for more info)
 
 ## Authentication
 


### PR DESCRIPTION
Got our SSL certificate to work with Cloudfront - at last!! Damn you Amazon and your horrendous UX. Updated readme, fixes #19 