### PR TITLE
Support for locked booking fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ localization: {
 
 You can customize the booking form fields and their settings in this section. Only the `name`, `email` and `comment` fields are enabled by default. The `name` and `email` fields have to be enabled and is always required (for the event creation to work properly). All other fields can be enabled/disabled.
 
-If you're collecting user information before loading the widget, it can be useful to inject it into the form by setting the `prefilled` keys - just pass in the values and they will be set upon load. Combine it with `disabled` to lock the fields to your options.
+If you're collecting user information before loading the widget, it can be useful to inject it into the form by setting the `prefilled` keys - just pass in the values and they will be set upon load. Combine it with `locked` to lock the fields for user input.
 
 See `/examples/fields.htm`
 
@@ -275,40 +275,40 @@ bookingFields: {
   name: {
     placeholder: 'Your full name',
     prefilled: false,
-    disabled: false
+    locked: false
   },
   email: {
     placeholder: 'Your e-mail',
     prefilled: false,
-    disabled: false
+    locked: false
   },
   comment: {
     enabled: true,
     placeholder: 'Write a comment (optional)',
     prefilled: false,
     required: false,
-    disabled: false
+    locked: false
   },
   phone: {
     enabled: false,
     placeholder: 'Your phone number',
     prefilled: false,
     required: false,
-    disabled: false
+    locked: false
   },
   voip: {
     enabled: false,
     placeholder: 'Your Skype username',
     prefilled: false,
     required: false,
-    disabled: false
+    locked: false
   },
   location: {
     enabled: false,
     placeholder: 'Location',
     prefilled: false,
     required: false,
-    disabled: false
+    locked: false
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Maintainer: Lasse Boisen Andersen ([la@timekit.io](mailto:la@timekit.io)). PR's 
 
 **Visit [booking.timekit.io](http://booking.timekit.io) to set up your account and generate a config.**
 
-Booking.js is meant as an easy to use, drop-in script that does it's job without any coding required. It's made for the browser and is quite similar to Stripe's Checkout.js. 
+Booking.js is meant as an easy to use, drop-in script that does it's job without any coding required. It's made for the browser and is quite similar to Stripe's Checkout.js.
 
 *This repo is mainly for community contributions and the curious soul that would like to customize the widget beyond settings provided in the wizard.*
 
@@ -104,7 +104,7 @@ Booking.js is made for various use-cases, so it's really extensible and customiz
   email:                    '',   // Your Timekit user's email (used for auth)
   apiToken:                 '',   // Your Timekit user's apiToken (as generated through the wizard)
   calendar:                 '',   // Your Timekit calendar ID that bookings should end up in
-  
+
   // Optional
   targetEl:                 '#bookingjs', // Which element should we the library load into
   name:                     '',   // Display name to show in the header and timezone helper
@@ -247,9 +247,9 @@ localization: {
 },
 ```
 
-For full language support, FullCalendar also takes a ["lang" option](http://fullcalendar.io/docs/text/lang/), accompanied by a language file. Make sure to use defer attribute on a script tag loading the language file if you are deferring booking.js, language file should be loaded after booking.js, but before initialization. 
+For full language support, FullCalendar also takes a ["lang" option](http://fullcalendar.io/docs/text/lang/), accompanied by a language file. Make sure to use defer attribute on a script tag loading the language file if you are deferring booking.js, language file should be loaded after booking.js, but before initialization.
 
-Remember to set `localization.timeDateFormat` to false so it doesn't override the language file's settings. 
+Remember to set `localization.timeDateFormat` to false so it doesn't override the language file's settings.
 
 See `/examples/local-language.htm`
 
@@ -266,7 +266,7 @@ localization: {
 
 You can customize the booking form fields and their settings in this section. Only the `name`, `email` and `comment` fields are enabled by default. The `name` and `email` fields have to be enabled and is always required (for the event creation to work properly). All other fields can be enabled/disabled.
 
-If you're collecting user information before loading the widget, it can be useful to inject it into the form by setting the `prefilled` keys - just pass in the values and they will be set upon load.
+If you're collecting user information before loading the widget, it can be useful to inject it into the form by setting the `prefilled` keys - just pass in the values and they will be set upon load. Combine it with `disabled` to lock the fields to your options.
 
 See `/examples/fields.htm`
 
@@ -274,35 +274,41 @@ See `/examples/fields.htm`
 bookingFields: {
   name: {
     placeholder: 'Your full name',
-    prefilled: false
+    prefilled: false,
+    disabled: false
   },
   email: {
     placeholder: 'Your e-mail',
-    prefilled: false
+    prefilled: false,
+    disabled: false
   },
   comment: {
     enabled: true,
     placeholder: 'Write a comment (optional)',
     prefilled: false,
-    required: false
+    required: false,
+    disabled: false
   },
   phone: {
     enabled: false,
     placeholder: 'Your phone number',
     prefilled: false,
-    required: false
+    required: false,
+    disabled: false
   },
   voip: {
     enabled: false,
     placeholder: 'Your Skype username',
     prefilled: false,
-    required: false
+    required: false,
+    disabled: false
   },
   location: {
     enabled: false,
     placeholder: 'Location',
     prefilled: false,
-    required: false
+    required: false,
+    disabled: false
   }
 }
 ```

--- a/examples/fields.htm
+++ b/examples/fields.htm
@@ -24,10 +24,11 @@
         },
         bookingFields: {
           name: {
-            placeholder: 'Your name please',
+            placeholder: 'Your name please'
           },
           email: {
-            prefilled: 'doc.brown@timekit.io'
+            prefilled: 'doc.brown@timekit.io',
+            disabled: true
           },
           comment: {
             enabled: false

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function(config) {
       { pattern: 'test/*.spec.js',          included: true,  served: true, watched: true },
       { pattern: 'test/fixtures/**/*.html', included: false, served: true, watched: true },
       { pattern: 'misc/**/*.*',             included: false, served: true, watched: false },
-      { pattern: 'dist/**/*',               included: false, served: true, watched: true }
+      { pattern: 'dist/**/*',               included: false, served: true, watched: true },
+      { pattern: 'src/**/*',                included: false, served: false, watched: true }
     ],
 
     // list of files to exclude

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -20,40 +20,40 @@ var primary = {
     name: {
       placeholder: 'Your full name',
       prefilled: false,
-      disabled: false
+      locked: false
     },
     email: {
       placeholder: 'Your e-mail',
       prefilled: false,
-      disabled: false
+      locked: false
     },
     comment: {
       enabled: true,
       placeholder: 'Write a comment (optional)',
       prefilled: false,
       required: false,
-      disabled: false
+      locked: false
     },
     phone: {
       enabled: false,
       placeholder: 'Your phone number',
       prefilled: false,
       required: false,
-      disabled: false
+      locked: false
     },
     voip: {
       enabled: false,
       placeholder: 'Your Skype username',
       prefilled: false,
       required: false,
-      disabled: false
+      locked: false
     },
     location: {
       enabled: false,
       placeholder: 'Location',
       prefilled: false,
       required: false,
-      disabled: false
+      locked: false
     }
   },
   timekitConfig: {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,35 +19,41 @@ var primary = {
   bookingFields: {
     name: {
       placeholder: 'Your full name',
-      prefilled: false
+      prefilled: false,
+      disabled: false
     },
     email: {
       placeholder: 'Your e-mail',
-      prefilled: false
+      prefilled: false,
+      disabled: false
     },
     comment: {
       enabled: true,
       placeholder: 'Write a comment (optional)',
       prefilled: false,
-      required: false
+      required: false,
+      disabled: false
     },
     phone: {
       enabled: false,
       placeholder: 'Your phone number',
       prefilled: false,
-      required: false
+      required: false,
+      disabled: false
     },
     voip: {
       enabled: false,
       placeholder: 'Your Skype username',
       prefilled: false,
-      required: false
+      required: false,
+      disabled: false
     },
     location: {
       enabled: false,
       placeholder: 'Location',
       prefilled: false,
-      required: false
+      required: false,
+      disabled: false
     }
   },
   timekitConfig: {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -252,6 +252,7 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
       box-sizing: border-box;
       line-height: normal;
       font-family: $fontFamily;
+      color: $textColor;
 
       &:focus {
         outline: 0;
@@ -260,6 +261,11 @@ $fontFamily:        'Open Sans', Helvetica, Tahoma, Arial, sans-serif;
 
       &.hidden {
         display: none;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        font-style: italic;
       }
     }
 

--- a/src/templates/booking-fields.html
+++ b/src/templates/booking-fields.html
@@ -5,6 +5,7 @@
   name="name"
   placeholder="{{ fields.name.placeholder }}"
   {{# fields.name.prefilled }} value="{{ fields.name.prefilled }}" {{/ fields.name.prefilled }}
+  {{# fields.name.disabled }} disabled="disabled" {{/ fields.name.disabled }}
   required
 />
 
@@ -14,6 +15,7 @@
   name="email"
   placeholder="{{ fields.email.placeholder }}"
   {{# fields.email.prefilled }} value="{{ fields.email.prefilled }}" {{/ fields.email.prefilled }}
+  {{# fields.email.disabled }} disabled="disabled" {{/ fields.email.disabled }}
   required
 />
 
@@ -25,6 +27,7 @@
     placeholder="{{ fields.phone.placeholder }}"
     {{# fields.phone.prefilled }} value="{{ fields.phone.prefilled }}" {{/ fields.phone.prefilled }}
     {{# fields.phone.required }} required {{/ fields.phone.required }}
+    {{# fields.phone.disabled }} disabled="disabled" {{/ fields.phone.disabled }}
   />
 {{/ fields.phone.enabled }}
 
@@ -36,6 +39,7 @@
     placeholder="{{ fields.voip.placeholder }}"
     {{# fields.voip.prefilled }} value="{{ fields.voip.prefilled }}" {{/ fields.voip.prefilled }}
     {{# fields.voip.required }} required {{/ fields.voip.required }}
+    {{# fields.voip.disabled }} disabled="disabled" {{/ fields.voip.disabled }}
   />
 {{/ fields.voip.enabled }}
 
@@ -47,6 +51,7 @@
     placeholder="{{ fields.location.placeholder }}"
     {{# fields.location.prefilled }} value="{{ fields.location.prefilled }}" {{/ fields.location.prefilled }}
     {{# fields.location.required }} required {{/ fields.location.required }}
+    {{# fields.location.disabled }} disabled="disabled" {{/ fields.location.disabled }}
   />
 {{/ fields.location.enabled }}
 
@@ -58,5 +63,6 @@
     placeholder="{{ fields.comment.placeholder }}"
     {{# fields.comment.prefilled }} value="{{ fields.comment.prefilled }}" {{/ fields.comment.prefilled }}
     {{# fields.comment.required }} required {{/ fields.comment.required }}
+    {{# fields.comment.disabled }} disabled="disabled" {{/ fields.comment.disabled }}
   />
 {{/ fields.comment.enabled }}

--- a/src/templates/booking-fields.html
+++ b/src/templates/booking-fields.html
@@ -5,7 +5,7 @@
   name="name"
   placeholder="{{ fields.name.placeholder }}"
   {{# fields.name.prefilled }} value="{{ fields.name.prefilled }}" {{/ fields.name.prefilled }}
-  {{# fields.name.disabled }} disabled="disabled" {{/ fields.name.disabled }}
+  {{# fields.name.locked }} disabled="disabled" {{/ fields.name.locked }}
   required
 />
 
@@ -15,7 +15,7 @@
   name="email"
   placeholder="{{ fields.email.placeholder }}"
   {{# fields.email.prefilled }} value="{{ fields.email.prefilled }}" {{/ fields.email.prefilled }}
-  {{# fields.email.disabled }} disabled="disabled" {{/ fields.email.disabled }}
+  {{# fields.email.locked }} disabled="disabled" {{/ fields.email.locked }}
   required
 />
 
@@ -27,7 +27,7 @@
     placeholder="{{ fields.phone.placeholder }}"
     {{# fields.phone.prefilled }} value="{{ fields.phone.prefilled }}" {{/ fields.phone.prefilled }}
     {{# fields.phone.required }} required {{/ fields.phone.required }}
-    {{# fields.phone.disabled }} disabled="disabled" {{/ fields.phone.disabled }}
+    {{# fields.phone.locked }} disabled="disabled" {{/ fields.phone.locked }}
   />
 {{/ fields.phone.enabled }}
 
@@ -39,7 +39,7 @@
     placeholder="{{ fields.voip.placeholder }}"
     {{# fields.voip.prefilled }} value="{{ fields.voip.prefilled }}" {{/ fields.voip.prefilled }}
     {{# fields.voip.required }} required {{/ fields.voip.required }}
-    {{# fields.voip.disabled }} disabled="disabled" {{/ fields.voip.disabled }}
+    {{# fields.voip.locked }} disabled="disabled" {{/ fields.voip.locked }}
   />
 {{/ fields.voip.enabled }}
 
@@ -51,7 +51,7 @@
     placeholder="{{ fields.location.placeholder }}"
     {{# fields.location.prefilled }} value="{{ fields.location.prefilled }}" {{/ fields.location.prefilled }}
     {{# fields.location.required }} required {{/ fields.location.required }}
-    {{# fields.location.disabled }} disabled="disabled" {{/ fields.location.disabled }}
+    {{# fields.location.locked }} disabled="disabled" {{/ fields.location.locked }}
   />
 {{/ fields.location.enabled }}
 
@@ -63,6 +63,6 @@
     placeholder="{{ fields.comment.placeholder }}"
     {{# fields.comment.prefilled }} value="{{ fields.comment.prefilled }}" {{/ fields.comment.prefilled }}
     {{# fields.comment.required }} required {{/ fields.comment.required }}
-    {{# fields.comment.disabled }} disabled="disabled" {{/ fields.comment.disabled }}
+    {{# fields.comment.locked }} disabled="disabled" {{/ fields.comment.locked }}
   />
 {{/ fields.comment.enabled }}

--- a/test/bookingFields.spec.js
+++ b/test/bookingFields.spec.js
@@ -136,4 +136,41 @@ describe('Booking fields', function() {
 
   });
 
+  fit('should be able to lock fields for user input', function(done) {
+
+    var config = {
+      bookingFields: {
+        name: {
+          locked: true,
+          prefilled: "My Test Name"
+        },
+        email: {
+          locked: false
+        }
+      }
+    }
+
+    createWidget(config);
+
+    setTimeout(function() {
+
+      interact.clickEvent();
+
+      setTimeout(function() {
+
+        var nameInput = $('.input-name');
+        expect(nameInput.prop('disabled')).toBe(true);
+        expect(nameInput.is('[disabled=disabled]')).toBe(true);
+
+        var emailInput = $('.input-email');
+        expect(emailInput.prop('disabled')).toBe(false);
+        expect(emailInput.is('[disabled=disabled]')).toBe(false);
+
+        done();
+
+      }, 500);
+    }, 500);
+
+  });
+
 });


### PR DESCRIPTION
Booking fields can now be locked so it's not editable by the user. Use in conjuction with `prefilled` 
Usage:
```
bookingFields: {
  name: {
    locked: true,
    prefilled: "My Test Name"
  }
}
```

@vistik 