### PR TITLE
Fixes a button hover 1px misalignment

### DIFF
--- a/src/styles/fullcalendar.scss
+++ b/src/styles/fullcalendar.scss
@@ -45,6 +45,8 @@ $primaryDarkColor: darken($primaryColor, 10%);
   text-transform: uppercase;
   font-weight: 600;
   font-size: 1.1em;
+  border: 0px;
+  outline: none;
 
   &:hover,
   &:visited,


### PR DESCRIPTION
It's subtle, but hovering the next/previous week and today buttons results in a 1px jump. This fixes that.

@vistik 