### PR TITLE
Google RSVP changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ timekitCreateBooking: {
   event: {    
     where:        'Online',        // Default, you may want to customize this to a specific location, TBD or whatever fits
     invite:       true,            // Default, makes sure that participants (the visitor) is sent a Google invite
-    my_rsvp:      'needsAction',   // Default, makes sure that the host also will be able to RSVP to the created event
+    my_rsvp:      'accepted',      // Default, makes sure that the host has accepted the created event in Google
     start:        data.start,      // Inserted dynamically from the chosen timeslot
     end:          data.end,        // Inserted dynamically from the chosen timeslot
     what:         config.name + ' x '+ data.name, // Inserted dynamically based on the host and visitors names (you can replace it with a static string)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Maintainer: Lasse Boisen Andersen ([la@timekit.io](mailto:la@timekit.io)). PR's 
 
 You can use the widget in two different ways:
 
-1) For non-developers, **[Hour](http://hourhq.com)** is a simple and easy to use availability and booking system made for sales & support scenarios.
-2) For developers, **[Timekit](http://timekit.io)** provides you with a modular and flexible API platform that allows you to integrate availability and bookings deep into your own product.
+1. For non-developers, **[Hour](http://hourhq.com)** is a simple and easy to use availability and booking system made for sales & support scenarios.  
+2. For developers, **[Timekit](http://timekit.io)** provides you with a modular and flexible API platform that allows you to integrate availability and bookings deep into your own product.
 
 *This repo is mainly for community contributions and the curious soul that would like to customize the widget.*
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -122,7 +122,7 @@ var bookingConfirmDecline = {
     action: 'create',
     event: {
       invite: true,
-      my_rsvp: 'needsAction',
+      my_rsvp: 'accepted',
       sync_provider: true
     }
   },

--- a/src/main.js
+++ b/src/main.js
@@ -427,7 +427,7 @@ function TimekitBooking() {
         where: 'TBD',
         description: '',
         calendar_id: config.calendar,
-        participants: [config.email, data.email]
+        participants: [data.email]
       },
       customer: {
         name: data.name,


### PR DESCRIPTION
- The host is not added as participant/guest, thus won't get double-events if using a seconday calendar
- Google events are always confirmed for the host and can't update RSVP (customer still can)

@vistik 