### PR TITLE
Support instant payments graph

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -117,6 +117,26 @@ var bookingInstant = {
 
 };
 
+// Preset: bookingGraph = 'instant_payment'
+var bookingInstantPayment = {
+
+  timekitCreateBooking: {
+    graph: 'instant_payment',
+    action: 'tentative',
+    event: {
+      invite: true,
+      my_rsvp: 'accepted',
+      sync_provider: true
+    }
+  },
+  localization: {
+    strings: {
+      successMessageBody: "We have received your payment and reserved your timeslot.<br /><br />Have a great day!"
+    }
+  }
+
+};
+
 // Preset: bookingGraph = 'confirm_decline'
 var bookingConfirmDecline = {
 
@@ -225,6 +245,7 @@ module.exports = {
     },
     bookingGraph: {
       'instant': bookingInstant,
+      'instant_payment': bookingInstantPayment,
       'confirm_decline': bookingConfirmDecline,
       'group_customer': bookingGroupCustomer,
       'group_customer_payment': bookingGroupCustomerPayment

--- a/test/advancedConfiguration.spec.js
+++ b/test/advancedConfiguration.spec.js
@@ -6,9 +6,6 @@ var moment = require('moment');
 var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 
-/**
- * Advanced configuration of the library
- */
 describe('Advanced configuration', function() {
 
   beforeEach(function(){

--- a/test/basicConfiguration.spec.js
+++ b/test/basicConfiguration.spec.js
@@ -6,9 +6,6 @@ var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic configuration of the library
- */
 describe('Basic configuration', function() {
 
   beforeEach(function(){

--- a/test/basicInteractions.spec.js
+++ b/test/basicInteractions.spec.js
@@ -6,9 +6,6 @@ var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic interaction of the library
- */
 describe('Basic interaction', function() {
 
   beforeEach(function(){

--- a/test/bookingConfiguration.spec.js
+++ b/test/bookingConfiguration.spec.js
@@ -6,9 +6,6 @@ var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic interaction of the library
- */
 describe('Booking configuration', function() {
 
   beforeEach(function(){

--- a/test/bookingFields.spec.js
+++ b/test/bookingFields.spec.js
@@ -6,9 +6,6 @@ var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic interaction of the library
- */
 describe('Booking fields', function() {
 
   beforeEach(function(){

--- a/test/configLoading.spec.js
+++ b/test/configLoading.spec.js
@@ -5,9 +5,6 @@ jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
 var mockAjax = require('./utils/mockAjax');
 var createWidget = require('./utils/createWidget');
 
-/**
- * Intilialize the library with plain build
- */
 describe('Config loading', function() {
 
   beforeEach(function(){

--- a/test/groupBookings.spec.js
+++ b/test/groupBookings.spec.js
@@ -6,9 +6,6 @@ var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic interaction of the library
- */
 describe('Group bookings', function() {
 
   beforeEach(function(){

--- a/test/hourCompatibility.spec.js
+++ b/test/hourCompatibility.spec.js
@@ -5,9 +5,6 @@ jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
 var createWidget = require('./utils/createWidget');
 var mockAjax = require('./utils/mockAjax');
 
-/**
- * Basic configuration of the library
- */
 describe('Hour compatibility configuration', function() {
 
   beforeEach(function(){

--- a/test/initialization.spec.js
+++ b/test/initialization.spec.js
@@ -5,9 +5,6 @@ jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
 var baseConfig = require('./utils/defaultConfig');
 var mockAjax = require('./utils/mockAjax');
 
-/**
- * Intilialize the library with plain build
- */
 describe('Initialization regular', function() {
 
   beforeEach(function(){
@@ -50,9 +47,6 @@ describe('Initialization regular', function() {
 
 });
 
-/**
- * Intilialize the library with minified build
- */
 describe('Initialization minified', function() {
 
   beforeEach(function(){

--- a/test/mobileResponsive.spec.js
+++ b/test/mobileResponsive.spec.js
@@ -8,9 +8,6 @@ var interact = require('./utils/commonInteractions');
 
 var browserWidth;
 
-/**
- * Tests for mobile and responsive
- */
 describe('Mobile & responsive', function() {
 
   beforeEach(function(){

--- a/test/teamAvailability.spec.js
+++ b/test/teamAvailability.spec.js
@@ -7,9 +7,6 @@ var teamAvailabilityConfig = require('./utils/teamAvailabilityConfig');
 var mockAjax = require('./utils/mockAjax');
 var interact = require('./utils/commonInteractions');
 
-/**
- * Basic interaction of the library
- */
 describe('Team availability', function() {
 
   beforeEach(function(){


### PR DESCRIPTION
Motivation
------------
There were no default settings for the `instant_payment` graph which made it harder (but not impossible) to get a quick integration up and running.

Features
------------
- Added a default config block for `bookingGraph: 'instant_payment'` settings
- Cleaned up in comments in test files

Tests
------------
N/A

Who should review it?
------------
@vistik 
