### PR TITLE
Full Calendar: Text/Time Customization changed form: 'lang' to 'locale'

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ See `/examples/local-language.htm`
 
 ```javascript
 fullCalendar: {
-  lang: 'de'
+  locale: 'de'
 },
 localization: {
   timeDateFormat: false

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ localization: {
 },
 ```
 
-For full language support, FullCalendar also takes a ["lang" option](http://fullcalendar.io/docs/text/lang/), accompanied by a language file. Make sure to use defer attribute on a script tag loading the language file if you are deferring booking.js, language file should be loaded after booking.js, but before initialization.
+For full language support, FullCalendar also takes a ["locale" option](http://fullcalendar.io/docs/text/lang/), accompanied by a language file. Make sure to use defer attribute on a script tag loading the language file if you are deferring booking.js, language file should be loaded after booking.js, but before initialization.
 
 Remember to set `localization.timeDateFormat` to false so it doesn't override the language file's settings.
 

--- a/examples/local-language.htm
+++ b/examples/local-language.htm
@@ -22,7 +22,7 @@
         avatar:   '../misc/avatar-doc.jpg',
         app:      'back-to-the-future',
         fullCalendar: {
-          lang: 'de'
+          locale: 'de'
         },
         localization: {
           timeDateFormat: false


### PR DESCRIPTION
### Full Calendar language variable update

Full Calendar has removed the `'lang'` variable for localization and replaced it with `'locale'` as per version 3. [Read More](https://fullcalendar.io/docs/text/locale/)

#### changelog:
- [x] Updated gist (show in help center article)
- [x] Updated help center article [Change the language on your projects widget](http://help.timekit.io/customizing-timekit/advanced-widget-settings/change-the-language-on-your-projects-widget)
- [x] Updated README