### PR TITLE
Create a new SDK instance for new widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "moment": "^2.10.6",
     "moment-timezone": "^0.5.13",
     "sprintf-js": "^1.0.3",
-    "timekit-sdk": "^1.7.0"
+    "timekit-sdk": "^1.9.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -11,8 +11,8 @@
 
 // External depenencies
 var $               = require('jquery');
-var timekit         = require('timekit-sdk');
 var interpolate     = require('sprintf-js');
+var timekitSDK      = require('timekit-sdk');
 window.fullcalendar = require('fullcalendar');
 var moment          = window.moment = require('moment');
 require('moment-timezone/builds/moment-timezone-with-data-2012-2022.js');
@@ -27,6 +27,9 @@ require('./styles/main.scss');
 
 // Main library
 function TimekitBooking() {
+
+  // SDK instance
+  var timekit = timekitSDK.newInstance();
 
   // Library config
   var config = {};

--- a/test/multipleInstances.spec.js
+++ b/test/multipleInstances.spec.js
@@ -1,0 +1,49 @@
+'use strict';
+
+jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
+
+var baseConfig = require('./utils/defaultConfig');
+var mockAjax = require('./utils/mockAjax');
+
+describe('Initialization regular', function() {
+
+  beforeEach(function(){
+    loadFixtures('main.html');
+    jasmine.Ajax.install();
+    mockAjax.all();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  it('should be able to create load multiple instances with isolated SDK configs', function() {
+
+    var widget1 = new TimekitBooking();
+    widget1.init({
+      email:    'marty.mcfly@timekit.io',
+      apiToken: 'XT1JO879JF1qUXXzmETD5ucgxaDwsFsd',
+      calendar: '22f86f0c-ee80-470c-95e8-dadd9d05edd2',
+      timekitConfig: {
+        app: 'widget-app-1'
+      }
+    });
+
+    var widget2 = new TimekitBooking();
+    widget2.init({
+      email:    'doc.brown@timekit.io',
+      apiToken: 'XT1JO879JF1qUXXzmETD5ucgxaDwsFsX',
+      calendar: '22f86f0c-ee80-470c-95e8-dadd9d05eddX',
+      timekitConfig: {
+        app: 'widget-app-2'
+      }
+    });
+
+    var widget1App = widget1.timekitSdk.getConfig().app
+    var widget2App = widget2.timekitSdk.getConfig().app
+
+    expect(widget1App).not.toEqual(widget2App);
+
+  });
+
+});

--- a/test/multipleInstances.spec.js
+++ b/test/multipleInstances.spec.js
@@ -5,7 +5,7 @@ jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
 var baseConfig = require('./utils/defaultConfig');
 var mockAjax = require('./utils/mockAjax');
 
-describe('Initialization regular', function() {
+describe('Multiple instances', function() {
 
   beforeEach(function(){
     loadFixtures('main.html');


### PR DESCRIPTION
Motivation
------------
There's an leaking issue when using multiple instances of the library on the same page, where config settings differ (app, user auth etc). The reason is that when the JS SDK is getting required through DI, a singleton is always returned which means that multiple widgets still refer to the same SDK instance and thus overwrites each other config settings. 

This PR makes sure that a new SDK instance is created for each new widget to keep config and state isolated from each other.

Design choices
------------
Depends on a new `newInstance` method on the SDK. Chose this path instead of creating the default behaviour of the SDK in order to keep backwards compatibility.

Tests
------------
Added one test.

Release dependencies
------------
https://github.com/timekit-io/js-sdk/pull/31

Who should review it
------------
@Trolzie 