### PR TITLE
Polyfill promises for IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "console-polyfill": "^0.2.2",
+    "es6-promise-promise": "^1.0.0",
     "fullcalendar": "^3.4.0",
     "moment": "^2.10.6",
     "moment-timezone": "^0.5.13",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,9 @@ module.exports = {
         new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en-gb/),
         new webpack.DefinePlugin({
           VERSION: JSON.stringify(packageJson.version)
+        }),
+        new webpack.ProvidePlugin({
+          Promise: 'es6-promise-promise'
         })
     ]
 };

--- a/webpack.config.min.js
+++ b/webpack.config.min.js
@@ -34,6 +34,9 @@ module.exports = {
         new webpack.optimize.DedupePlugin(),
         new webpack.DefinePlugin({
           VERSION: JSON.stringify(packageJson.version)
+        }),
+        new webpack.ProvidePlugin({
+          Promise: 'es6-promise-promise'
         })
     ]
 };


### PR DESCRIPTION
Although the JS SDK already uses this polyfill, it's lost when building booking.js (for some reason). This adds it explicitly to booking.js too.

Updated the PR https://github.com/timekit-io/booking-js/pull/129 with newest `master` base. 