### PR TITLE
Using yarn on Circle CI & bump JS-SDK version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 5.1.1
+    version: 6.11.1
   environment:
     # Make sure that bins are available to yarn
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,21 @@
 machine:
   node:
     version: 5.1.1
+  environment:
+    # Make sure that bins are available to yarn
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+
+experimental:
+   notify:
+     branches:
+       only:
+         - master
 
 dependencies:
+  cache_directories:
+    - ~/.cache/yarn
   override:
-    - npm install
+    - yarn install --pure-lockfile
     - npm rebuild node-sass
 post:
     - cp npm-debug.log "$CIRCLE_ARTIFACTS/npm-debug.log"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,15 @@
   },
   "author": "Timekit Inc.",
   "license": "MIT",
+  "dependencies": {
+    "console-polyfill": "^0.2.2",
+    "es6-promise-promise": "^1.0.0",
+    "fullcalendar": "^3.4.0",
+    "moment": "^2.10.6",
+    "moment-timezone": "^0.5.13",
+    "sprintf-js": "^1.0.3",
+    "timekit-sdk": "^1.10.1"
+  },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
     "css-loader": "^0.21.0",
@@ -41,14 +50,5 @@
     "style-loader": "^0.13.0",
     "svg-inline-loader": "^0.3.0",
     "webpack": "^1.12.2"
-  },
-  "dependencies": {
-    "console-polyfill": "^0.2.2",
-    "es6-promise-promise": "^1.0.0",
-    "fullcalendar": "^3.4.0",
-    "moment": "^2.10.6",
-    "moment-timezone": "^0.5.13",
-    "sprintf-js": "^1.0.3",
-    "timekit-sdk": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "moment": "^2.10.6",
     "moment-timezone": "^0.5.13",
     "sprintf-js": "^1.0.3",
-    "timekit-sdk": "^1.9.0"
+    "timekit-sdk": "^1.10.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,9 +4085,9 @@ through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-timekit-sdk@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/timekit-sdk/-/timekit-sdk-1.9.0.tgz#6cd9fae768b1e79c1e01fb6e80d0578d65d86acd"
+timekit-sdk@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/timekit-sdk/-/timekit-sdk-1.10.0.tgz#ba62a0108d2c5c483dc2c9fb935cefb7852b6c15"
   dependencies:
     axios "^0.12.0"
     base-64 "^0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,9 +4085,9 @@ through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-timekit-sdk@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/timekit-sdk/-/timekit-sdk-1.10.0.tgz#ba62a0108d2c5c483dc2c9fb935cefb7852b6c15"
+timekit-sdk@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/timekit-sdk/-/timekit-sdk-1.10.1.tgz#a5b714578191bed703f4a13251cea12977b8d349"
   dependencies:
     axios "^0.12.0"
     base-64 "^0.1.0"


### PR DESCRIPTION
Streamline the testing setup on Circle CI to use the yarn lockfile

Also bumped JS SDK version to newest