### PR TITLE
Dependent projects warning for deploys

### DIFF
--- a/flux.json
+++ b/flux.json
@@ -11,10 +11,11 @@
   "deploy": {
     "prod": {
       "check-git-master": true,
-      "publish-to-npm": true,
       "install-npm-deps": true,
       "build-dist-bundle": "yarn run build",
-      "aws-cdn-deploy": "timekit-cdn"
+      "aws-cdn-deploy": "timekit-cdn",
+      "publish-to-npm": true,
+      "dependent-projects": ["admin"]
     },
     "staging": {
       "build-dist-bundle": "yarn run build",


### PR DESCRIPTION
Shows a warning that reminds to re-deploy `admin` when a new deployment of `booking-js` is made.

Relies on this PR for flux: https://github.com/timekit-io/flux/pull/11