### PR TITLE
Updated `instant_payment` graph support

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -121,7 +121,7 @@ var bookingInstantPayment = {
 
   timekitCreateBooking: {
     graph: 'instant_payment',
-    action: 'tentative',
+    action: 'create',
     event: {
       invite: true,
       my_rsvp: 'accepted',


### PR DESCRIPTION
When used `bookingGraph: 'instant_payment'` option. I've got this error
```
"Cannot apply action 'tentative' to current state 'initialized'"
```

According to the API docs [](http://developers.timekit.io/docs/payments) action should be `create` instead of `tentative`