### PR TITLE
Add location on customer key

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -683,7 +683,7 @@ function TimekitBooking() {
     };
 
     if (config.bookingFields.location.enabled) {
-      args.customer.where = formData.where;
+      args.customer.where = formData.location;
       args.event.where = formData.location;
     }
     if (config.bookingFields.comment.enabled) {

--- a/src/main.js
+++ b/src/main.js
@@ -682,7 +682,10 @@ function TimekitBooking() {
       }
     };
 
-    if (config.bookingFields.location.enabled) { args.event.where = formData.location; }
+    if (config.bookingFields.location.enabled) {
+      args.customer.where = formData.where;
+      args.event.where = formData.location;
+    }
     if (config.bookingFields.comment.enabled) {
       args.customer.comment = formData.comment;
       args.event.description += config.bookingFields.comment.placeholder + ': ' + formData.comment + '\n';


### PR DESCRIPTION
A customer is using location field, but find it wired that location is the only thing not being added to the customer key. This is something i agree with, and so we are added location to the customer key: `customer.where`

@jariwiklund / @vistik 