### PR TITLE
Bugfix: undefined event description when creating bookings

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -549,6 +549,7 @@ function InitRender(deps) {
     var args = {
       start: eventData.start.format(),
       end: eventData.end.format(),
+      description: '',
       customer: {
         name: formData.name,
         email: formData.email,
@@ -561,8 +562,7 @@ function InitRender(deps) {
     } else {
       $.extend(true, args, {
         what: 'Meeting with ' + formData.name,
-        where: 'TBD',
-        description: ''
+        where: 'TBD'
       });
     }
 
@@ -572,15 +572,15 @@ function InitRender(deps) {
     }
     if (getConfig().customer_fields.comment) {
       args.customer.comment = formData.comment;
-      args.description += (getConfig().customer_fields.comment.title || 'comment') + ': ' + formData.comment + '\n';
+      args.description += (getConfig().customer_fields.comment.title || 'Comment') + ': ' + formData.comment + '\n';
     }
     if (getConfig().customer_fields.phone) {
       args.customer.phone = formData.phone;
-      args.description += (getConfig().customer_fields.phone.title || 'phone') + ': ' + formData.phone + '\n';
+      args.description += (getConfig().customer_fields.phone.title || 'Phone') + ': ' + formData.phone + '\n';
     }
     if (getConfig().customer_fields.voip) {
       args.customer.voip = formData.voip;
-      args.description += (getConfig().customer_fields.voip.title || 'voip') + ': ' + formData.voip + '\n';
+      args.description += (getConfig().customer_fields.voip.title || 'Voip') + ': ' + formData.voip + '\n';
     }
 
     if (getConfig().booking.graph === 'group_customer' || getConfig().booking.graph === 'group_customer_payment') {


### PR DESCRIPTION
Motivation
------------
This fixes a minor issue that can occur when using projects and using the comment/phone/voip customer field will result in appending to the `args.description` key without it having any initial value.

The erroneous description would end us as:
`description: 'undefinedComment: some comment here'` 

Who should review it
------------
@Trolzie 