### PR TITLE
Fix test-mode ribbon glitch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+Motivation
+------------
+
+
+UI & UX
+------------
+
+
+Specs
+------------
+
+
+Design choices
+------------
+
+
+Side-effects/other
+------------
+
+
+Tests
+------------
+
+
+Known issues/limitations
+------------
+
+
+Tracking
+------------
+
+
+Release dependencies
+------------
+
+
+Who should review it
+------------

--- a/src/styles/testmoderibbon.scss
+++ b/src/styles/testmoderibbon.scss
@@ -13,7 +13,7 @@
   right: 19px;
   transform: rotate(45deg);
   overflow: hidden;
-  z-index: 32;
+  z-index: 42;
   -webkit-backface-visibility: hidden;
 
   .bookingjs-ribbon-container {
@@ -73,7 +73,7 @@
         font-size: 10px;
         color: $bgColor;
         text-transform: uppercase;
-        font-weight: 400;
+        font-weight: 700;
         letter-spacing: 1px;
         line-height: 1;
       }


### PR DESCRIPTION
Motivation
------------
Fixes a z-index glitch where testmode ribbon is hidden behind the footer bar.

Also increases the font-weight of the ribbon text a bit.

Also added a Github PR template as a default.

UI & UX
------------
Before:
<img width="240" alt="screen shot 2018-10-10 at 14 40 31" src="https://user-images.githubusercontent.com/222419/46736993-b3e59e80-cc9a-11e8-8243-e5cb6c6e0e51.png">

After:
<img width="257" alt="screen shot 2018-10-10 at 14 40 12" src="https://user-images.githubusercontent.com/222419/46737004-b942e900-cc9a-11e8-974c-e22240018898.png">

Who should review it
------------
@vistik 